### PR TITLE
Imporve the styling of the display of the metadata details on mobile devices 

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -98,7 +98,25 @@
 	
 		var fieldset = $fieldset.get(0);
                 Drupal.toggleFieldset(fieldset);
-
+	
+		$("[class^='dc-']dt").each(function(){
+		    $(this).css('padding-right','100px');
+		});
+		$("[class^='dc-']dd").each(function(){
+		    var textNode = $(this).first();
+		    if(!textNode){
+			$(this).prepend(document.createTextNode('Some text'));
+		    }
+		    else{
+			var text = textNode.text();
+			if(!text || text == '' || text == "\n                  "){
+			    textNode.text('ok');			    
+//$(this).prepend("<div style='visibility:hidden'><span>No information to display</span></div>");
+			}
+		    }
+		    $(this).css('padding-right','100px');
+		});
+	
 		$legend.append(summary);
             });
         }

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -101,6 +101,9 @@
 	
 		$("[class^='dc-']dt").each(function(){
 		    $(this).css('padding-right','100px');
+		    if($(window).width() < 548){
+		    	$(this).css('border','none');
+		    }
 		});
 		$("[class^='dc-']dd").each(function(){
 		    var textNode = $(this).first();
@@ -110,13 +113,14 @@
 		    else{
 			var text = textNode.text();
 			if(!text || text == '' || text == "\n                  "){
-			    textNode.text('ok');			    
-//$(this).prepend("<div style='visibility:hidden'><span>No information to display</span></div>");
+			    $(this).prepend("<div style='visibility:hidden'><span>No information to display</span></div>");
 			}
 		    }
 		    $(this).css('padding-right','100px');
+		    if($(window).width() < 548){
+		    	$(this).css('border','none');
+		    }
 		});
-	
 		$legend.append(summary);
             });
         }


### PR DESCRIPTION
The label and content of the metadata of the books overlap on iphone 5. 
This fix should result in normal display of the metadata on mobile devices.
