### PR TITLE
Kludge fix page load jump by disabling scrolling on fieldset toggle.

### DIFF
--- a/js/collapse.js
+++ b/js/collapse.js
@@ -17,12 +17,20 @@
                 duration: 'fast',
                 easing: 'linear',
                 complete: function () {
-                    Drupal.collapseScrollIntoView(fieldset);
+                  // FIXME
+                  // We'er misusing js to make sure some fieldsets are never
+                  // collapsed, so we have to disable scrolling when we toggle
+                  // them. 
+                    //Drupal.collapseScrollIntoView(fieldset);
                     fieldset.animating = false;
                 },
                 step: function () {
+                  // FIXME
+                  // We'er misusing js to make sure some fieldsets are never
+                  // collapsed, so we have to disable scrolling when we toggle
+                  // them.
                     // Scroll the fieldset into view.
-                    Drupal.collapseScrollIntoView(fieldset);
+                    //Drupal.collapseScrollIntoView(fieldset);
                 }
             });
 	  // Remove the code logic that hides the content


### PR DESCRIPTION
We've misused JavaScript to ensure that the fieldset displaying metadata is never hidden, so we need to hack around the JS that would normally scroll a hidden fieldset into view when toggled. 

This is kind of ugly, and the real fix would be to throw this junk away and redo how the metadata table gets displayed in the first place. 